### PR TITLE
Statically link standard libraries with binary

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -4,3 +4,5 @@ pybind11_add_module(${PROJECT_NAME}py
 target_link_libraries(${PROJECT_NAME}py PUBLIC ${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}py PUBLIC carma::carma)
+
+target_link_libraries(${PROJECT_NAME}py PRIVATE -static-libgcc -static-libstdc++)


### PR DESCRIPTION
Hi,

I've been using your library for some time now and am happy with its capabilities. Thank you for developing it; it has proven useful for my project! However, I ran into some strange errors that required some deeper investigation. In the following, I wanted to document what went wrong and how it can be fixed. It may be useful to spare some valuable time for someone having a similar issue.

To supply some context, I use `xfac` to interpolate over a hard-to-sample function using Python. I use `conda` to manage my environment. For development, I use a variety of scientific Python packages, including `numpy` (its headers are somehow required by `xfac`'s make script) and `scipy`. Recently, I used `xfac` in a Jupyter notebook. I saw the following error message when importing the library, though. (I replaced paths with `<path to ...>` for better readability and added line breaks.)

```
<path to conda env>/lib/python3.11/site-packages/zmq/backend/cython/../../../../.././libstdc++.so.6:
version `GLIBCXX_3.4.32' not found
(required by <path to xfac>/build/python/xfacpy.cpython-311-x86_64-linux-gnu.so)
```

I've tried the same notebook on a different machine, and there it worked. So, I concluded that the malfunction must have been due to the faulty setup of my development machine.

After a while of debugging with `LD_DEBUG=files`, I found out that Jupyter loads a version of `libstdc++` (a version that is bundled with `conda`) when setting up its internal message broker _before_ the `xfac` shared library is loaded. When running a "naked" Python script that loads `xfac`, the loader picks a different `libstdc++` (the one from `/usr/lib/...`) and I don't get the error message. 

Therefore, I believe that the standard libraries are somehow incompatible, and `xfac` requires a very specific copy of the standard library. I am unsure how other Python packages do it, but `xfac` seemed to be the only one with that problem. (Jupyter and `scipy` run happily with the standard library that `conda` ships.) This may be because I compiled `xfac` from scratch on my machine, and the linker just happened to pick the system's copy of `libstdc++` as its library of choice.

Of course, this is due to my setup. However, I think it would be nice if `xfac` would not rely on the choice of the standard library version. This pull request contains one possible solution that solved the problem: the updated `cmake` script bundles the standard library with `xfac` when building the Python binaries. Therefore, the latter is not dependent on the external library version. That's not the most elegant solution, but it's the one that solved my problem.

It would be amazing if `xfac`'s build script could respect the environment it's running in. However, I am not sure how that can be achieved. Maybe it would be the best option to supply a `pyproject.toml` configuration to make the package manager able to decide in what context the library should be executed. Also, it would make the fact obsolete, as the library is a bit cumbersome to use right now since it always requires manually adding the library to the path using `sys.path`.

I hope this discussion is helpful. Feel free to reach out to me! I am thankful for any feedback. Maybe my assumptions are completely wrong, and I've just been using the library incorrectly. 

Best,
Johannes