### PR TITLE
Fixes

### DIFF
--- a/include/xfac/grid.h
+++ b/include/xfac/grid.h
@@ -111,7 +111,7 @@ struct Quantics {
         return us;
     }
 
-    void save(std::ostream &out) const { out<<a<<" "<<b<<" "<<nBit<<" "<<dim<<" "<<fused<<std::endl; }
+    void save(std::ostream &out) const { out<<std::setprecision(18)<<a<<" "<<b<<" "<<nBit<<" "<<dim<<" "<<fused<<std::endl; }
 
     static Quantics load(std::istream& in)
     {

--- a/test/test_matrix_ci.cpp
+++ b/test/test_matrix_ci.cpp
@@ -7,6 +7,7 @@ using namespace arma;
 using namespace xfac;
 
 using cmpx=std::complex<double>;
+using uint = unsigned int;
 
 TEST_CASE( "Test MatrixCI" )
 {


### PR DESCRIPTION
Add missing uint definition and a fix for the grid::Quantics.save method which can lead to rounding issues.